### PR TITLE
Added .features + example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This extension adds a block to decribe the procurement procedure.
 
 ## Legal context
 
-In the European Union, this extension's fields correspond to [eForms BT-88, BT-106, BT-1351](https://github.com/eForms/eForms) and [Article 93 and 45 clause 3 of Directive 2014/25/EU](https://eur-lex.europa.eu/eli/dir/2014/25/oj). See [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/) for the correspondences to Tenders Electronic Daily (TED).
+In the European Union, this extension's fields correspond to [eForms BT-88, BT-106, BT-1351](https://github.com/eForms/eForms) and [Article 93 and 45(3) of Directive 2014/25/EU](https://eur-lex.europa.eu/eli/dir/2014/25/oj). See [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/) for the correspondences to Tenders Electronic Daily (TED).
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This extension adds a block to decribe the procurement procedure.
 
+
+
 ## Example
 
 ```json
@@ -9,9 +11,9 @@ This extension adds a block to decribe the procurement procedure.
   "tender": {
     "procedure": {
       "isAccelerated": true,
-      "acceleratedRationale": "The medicinal product is of major public health interest particularly from the point of view of therapeutic innovation."
-    },
-    "features": "http://www.legislation.gov.uk/uksi/2015/102/pdfs/uksi_20150102_en.pdf"
+      "acceleratedRationale": "The medicinal product is of major public health interest particularly from the point of view of therapeutic innovation.",
+      "features": "http://www.legislation.gov.uk/uksi/2015/102/pdfs/uksi_20150102_en.pdf"
+    }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This extension adds a block to decribe the procurement procedure.
     "procedure": {
       "isAccelerated": true,
       "acceleratedRationale": "The medicinal product is of major public health interest particularly from the point of view of therapeutic innovation."
-    }
+    },
+    "features": "http://www.legislation.gov.uk/uksi/2015/102/pdfs/uksi_20150102_en.pdf"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This extension adds a block to decribe the procurement procedure.
 
+## Legal context
 
+In the European Union, this extension's fields correspond to [eForms BT-88, BT-106, BT-1351](https://github.com/eForms/eForms) and [Article 93 and 45 clause 3 of Directive 2014/25/EU](https://eur-lex.europa.eu/eli/dir/2014/25/oj). See [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/) for the correspondences to Tenders Electronic Daily (TED).
 
 ## Example
 

--- a/release-schema.json
+++ b/release-schema.json
@@ -32,7 +32,7 @@
         },
         "features": {
           "title": "Features",
-          "description": "The national rules that apply to the procedure.",
+          "description": "The main features of the procedure (e.g. description of the individual stages) and information about where the full rules for the procedure can be found.",
           "type": [
             "string",
             "null"

--- a/release-schema.json
+++ b/release-schema.json
@@ -29,6 +29,14 @@
             "string",
             "null"
           ]
+        },
+        "features": {
+          "title": "Features",
+          "description": "The national rules that apply to the procedure.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     }


### PR DESCRIPTION
It took some time until I figured out the name of the field `features` came from the matching BT in eForms!

This PR adds:

- `features` in schema
- legal context for `features` and `acceleratedProcedure`
- example for `features`
